### PR TITLE
Doc enhancements

### DIFF
--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -100,6 +100,7 @@ async def search_google(query: str) -> str:
     await page.wait_for_load_state()
     return f'🔍 Searched for "{query}" in Google'
 
+
 @mcp.tool()
 async def go_to_url(url: str) -> str:
     """


### PR DESCRIPTION
### Summary

-  While adding `uvx mcp-browser-use` claude was throwing up since the uvx path was missing.
- Add a note to add the full config so it's easier to get started.
- Example claude config
```json
{
  "mcpServers": {
    "mcp-browser-use": {
      "command": "/Users/kracekumar/.local/bin/uvx",
      "args": ["mcp-browser-use"] 
    }
  }
}
```
- Remove `$` since the intention is to copy the command and paste in terminal or mcp config.